### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/io.github.alescdb.mailviewer.json
+++ b/io.github.alescdb.mailviewer.json
@@ -23,12 +23,10 @@
   },
   "cleanup": [
     "/include",
+    "/lib/girepository-1.0",
     "/lib/pkgconfig",
-    "/man",
-    "/share/doc",
-    "/share/gtk-doc",
-    "/share/man",
-    "/share/pkgconfig",
+    "/share/gir-1.0",
+    "/share/vala",
     "*.la",
     "*.a"
   ],


### PR DESCRIPTION
- Drop ineffective cleanup commands
- Improve cleanup commands to reduce the Flatpak size

The installed size has been reduced to 7 MB.